### PR TITLE
[PR] Mark a web-template request as 200 OK and set is_404 to false

### DIFF
--- a/includes/web-template.php
+++ b/includes/web-template.php
@@ -66,6 +66,8 @@ class WSUWP_Web_Template {
 	 * the JSON is output.
 	 */
 	public function handle_template_request() {
+		global $wp_query;
+
 		if ( $this->is_template_request() ) {
 			if ( isset( $_GET['html_title'] ) ) {
 				$this->html_title = $_GET['html_title'];
@@ -76,6 +78,8 @@ class WSUWP_Web_Template {
 			$post = $this->build_post_content();
 			remove_filter( 'spine_get_title', array( $this, 'set_html_title' ) );
 
+			status_header( 200 );
+			$wp_query->is_404 = false;
 			header('HTTP/1.1 200 OK');
 			header('Content-Type: application/json');
 			echo json_encode( array( 'before_content' => $pre, 'after_content' => $post ) );


### PR DESCRIPTION
If we don't do this, WordPress gets confused because it doesn't think the resource exists. Because we haven't told it. :)